### PR TITLE
Add introductory vocational training note to gastronomy scene

### DIFF
--- a/scenes/berufsschule-gastronomie-de-ru.html
+++ b/scenes/berufsschule-gastronomie-de-ru.html
@@ -212,6 +212,10 @@
     <div class="dialogue">
       <div class="line">
         <span class="who">Herr König</span>
+        <p class="de">Zur Erinnerung: Unsere Berufsschule bietet vielfältige Ausbildungen an, besonders für Gastronomieberufe, und euer Kurs zeigt heute, wie praxisnah das sein kann.</p>
+      </div>
+      <div class="line">
+        <span class="who">Herr König</span>
         <p class="de">Schön, dass alle da sind. Wir müssen heute klären, wie wir die Servicepraxis mit der neuen Lehrküche verzahnen.</p>
       </div>
       <div class="line">
@@ -283,6 +287,10 @@
       <span>Мастерский экзамен</span>
     </p>
     <div class="dialogue">
+      <div class="line">
+        <span class="who">Господин Кёниг</span>
+        <p class="ru">Напомню: наше профессиональное училище предлагает разные программы, особенно по гастрономическим специальностям, и ваш курс сегодня прекрасно показывает, насколько практика здесь жива.</p>
+      </div>
       <div class="line">
         <span class="who">Господин Кёниг</span>
         <p class="ru">Рад, что все пришли. Сегодня нам нужно решить, как связать практику обслуживания с новой учебной кухней.</p>


### PR DESCRIPTION
## Summary
- add a German opening remark referencing the vocational training focus of the gastronomy program
- provide the matching Russian translation to keep the bilingual scene aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da88a4920483258090dd242c1993bf